### PR TITLE
"lxc.aa_profile" to "lxc.apparmor.profile" to fix #126

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -369,7 +369,7 @@ profiles:
       boot.autostart: true
       linux.kernel_modules: bridge,br_netfilter,x_tables,ip_tables,ip6_tables,ip_vs,ip_set,ipip,xt_mark,xt_multiport,ip_tunnel,tunnel4,netlink_diag,nf_conntrack,nfnetlink,nf_nat,overlay
       raw.lxc: |
-        lxc.aa_profile=unconfined
+        lxc.apparmor.profile=unconfined
         lxc.mount.auto=proc:rw sys:rw cgroup-full:rw
         lxc.cap.drop=
         lxc.cgroup.devices.allow=a


### PR DESCRIPTION
Looks like there are changed configuration keys in the version of lxc that is being used (lxc info shows driver version 3.0.1). The updated table of keys can be found here: https://discuss.linuxcontainers.org/t/lxc-2-1-has-been-released/487..

Changing key “lxc.aa_profile” to “lxc.apparmor.profile” in Vagrantfile fixes the install issue documented in issue #126.